### PR TITLE
Removed usage of register, unregister and setDeviceFilter function from USBMonitor

### DIFF
--- a/libuvccamera/src/main/java/com/herohan/uvcapp/CameraConnectionService.java
+++ b/libuvccamera/src/main/java/com/herohan/uvcapp/CameraConnectionService.java
@@ -158,23 +158,10 @@ class CameraConnectionService {
         @Override
         public void register(final ICameraHelper.StateCallback callback) {
             mWeakStateCallback = new WeakReference<>(callback);
-
-            if (mUSBMonitor != null) {
-                if (DEBUG) Log.d(TAG, "mUSBMonitor#register:");
-                final List<DeviceFilter> filters = DeviceFilter.getDeviceFilters(UVCUtils.getApplication(), R.xml.device_filter);
-                mUSBMonitor.setDeviceFilter(filters);
-                mUSBMonitor.register();
-            }
         }
 
         @Override
         public void unregister(final ICameraHelper.StateCallback callback) {
-            if (mUSBMonitor != null) {
-                if (DEBUG) Log.d(TAG, "mUSBMonitor#unregister:");
-                mUSBMonitor.unregister();
-                mUSBMonitor = null;
-            }
-
             mWeakStateCallback.clear();
         }
 

--- a/libuvccamera/src/main/java/com/serenegiant/usb/USBMonitor.java
+++ b/libuvccamera/src/main/java/com/serenegiant/usb/USBMonitor.java
@@ -217,7 +217,7 @@ public final class USBMonitor {
                 final IntentFilter filter = new IntentFilter(ACTION_USB_PERMISSION);
                 // ACTION_USB_DEVICE_ATTACHED never comes on some devices so it should not be added here
                 filter.addAction(UsbManager.ACTION_USB_DEVICE_DETACHED);
-
+                context.registerReceiver(mUsbReceiver, filter);
             }
             // start connection check
             mDetectedDeviceKeys.clear();
@@ -241,7 +241,7 @@ public final class USBMonitor {
             final Context context = mWeakContext.get();
             try {
                 if (context != null) {
-
+                    context.unregisterReceiver(mUsbReceiver);
                 }
             } catch (final Exception e) {
                 Log.w(TAG, e);

--- a/libuvccamera/src/main/java/com/serenegiant/usb/USBMonitor.java
+++ b/libuvccamera/src/main/java/com/serenegiant/usb/USBMonitor.java
@@ -165,7 +165,7 @@ public final class USBMonitor {
      */
     public void destroy() {
         if (DEBUG) Log.i(TAG, "destroy:");
-        unregister();
+
         if (!mDestroyed) {
             mDestroyed = true;
 

--- a/libuvccamera/src/main/java/com/serenegiant/usb/USBMonitor.java
+++ b/libuvccamera/src/main/java/com/serenegiant/usb/USBMonitor.java
@@ -217,7 +217,7 @@ public final class USBMonitor {
                 final IntentFilter filter = new IntentFilter(ACTION_USB_PERMISSION);
                 // ACTION_USB_DEVICE_ATTACHED never comes on some devices so it should not be added here
                 filter.addAction(UsbManager.ACTION_USB_DEVICE_DETACHED);
-                context.registerReceiver(mUsbReceiver, filter);
+
             }
             // start connection check
             mDetectedDeviceKeys.clear();
@@ -241,7 +241,7 @@ public final class USBMonitor {
             final Context context = mWeakContext.get();
             try {
                 if (context != null) {
-                    context.unregisterReceiver(mUsbReceiver);
+
                 }
             } catch (final Exception e) {
                 Log.w(TAG, e);


### PR DESCRIPTION
Removed usage of register and unregister function from USBMonitor. Also removed usage of setDeviceFilter, it won't be needed since the receiver will never do anything.