### PR TITLE
Allow using UVC Camera without registering broadcast receiver

### DIFF
--- a/libuvccamera/src/main/java/com/herohan/uvcapp/CameraConnectionService.java
+++ b/libuvccamera/src/main/java/com/herohan/uvcapp/CameraConnectionService.java
@@ -56,7 +56,7 @@ class CameraConnectionService {
         private USBMonitor mUSBMonitor;
         private HandlerThread mListenerHandlerThread;
         private Handler mListenerHandler;
-        private WeakReference<ICameraHelper.StateCallback> mWeakStateCallback;
+        private WeakReference<ICameraHelper.StateCallback> mWeakStateCallback = new WeakReference<>(null);
 
         CameraConnection() {
             mListenerHandlerThread = new HandlerThread(LOG_PREFIX + hashCode());

--- a/libuvccamera/src/main/java/com/serenegiant/usb/USBMonitor.java
+++ b/libuvccamera/src/main/java/com/serenegiant/usb/USBMonitor.java
@@ -501,12 +501,12 @@ public final class USBMonitor {
     public void requestPermission(final UsbDevice device) {
         if (DEBUG) Log.v(TAG, "requestPermission:device=" + device.getDeviceName());
         synchronized (USBMonitor.class) {
-            if (isRegistered()) {
-                if (device != null) {
+            if (device != null) {
+                if (!mDestroyed) {
                     if (mUsbManager.hasPermission(device)) {
                         // call onConnect if app already has permission
                         processOpenDevice(device);
-                    } else {
+                    } else if (mPermissionIntent != null) {
                         try {
                             // if no usb permission, request permission
                             mUsbManager.requestPermission(device, mPermissionIntent);
@@ -515,12 +515,12 @@ public final class USBMonitor {
                             Log.w(TAG, e);
                             processCancel(device);
                         }
+                    } else {
+                        processCancel(device);
                     }
                 } else {
                     processCancel(device);
                 }
-            } else {
-                processCancel(device);
             }
         }
     }


### PR DESCRIPTION
Had to also adjust the function isRegistere() in USBMonitor since it relied on previous logic of it handling it's own Devices. Since mPendingIntent will always be null if no setStateCallBack is ever done, then it will always return false.